### PR TITLE
Fix a couple of small issues

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,7 @@
 (lang dune 3.0)
 
+(name mirage-net-unikraft)
+
 (generate_opam_files)
 
 (source (github mirage/mirage-net-unikraft))

--- a/src/netbuf.c
+++ b/src/netbuf.c
@@ -8,6 +8,8 @@
  *               All rights reserved.
 */
 
+#ifdef __Unikraft__
+
 #include "netif.h"
 
 // Size of the buffer area for uk_netbuf allocation
@@ -46,3 +48,5 @@ struct uk_netbuf *netdev_alloc_tx_netbuf(const struct netif *netif)
   }
   return netbuf;
 }
+
+#endif /* __Unikraft__ */

--- a/src/netdev.c
+++ b/src/netdev.c
@@ -8,6 +8,8 @@
  *               All rights reserved.
 */
 
+#ifdef __Unikraft__
+
 #include "netif.h"
 #include "result.h"
 
@@ -232,3 +234,5 @@ CAMLprim value uk_netdev_mtu(value v_netif)
 
     CAMLreturn(Val_int((int)mtu));
 }
+
+#endif /* __Unikraft__ */

--- a/src/netif.h
+++ b/src/netif.h
@@ -8,6 +8,8 @@
  *               All rights reserved.
 */
 
+#ifdef __Unikraft__
+
 #ifndef NETIF_H
 #define NETIF_H
 
@@ -32,3 +34,5 @@ uint16_t netdev_alloc_rxpkts(void *argp, struct uk_netbuf *nb[],
         uint16_t count);
 
 #endif /* !NETIF_H */
+
+#endif /* __Unikraft__ */

--- a/src/netif.ml
+++ b/src/netif.ml
@@ -142,7 +142,7 @@ let rec read t buf =
   | Error `Continue ->
       Unikraft_os.Main.Uk_engine.wait_for_work_netdev t.id >>= fun () ->
       read t buf
-  | Error (`Generic_error msg) as err -> Lwt.return err
+  | Error (`Generic_error _) as err -> Lwt.return err
   | Ok buf -> Lwt.return (Ok buf)
 
 (* Loop and listen for packets permanently *)

--- a/src/rx.c
+++ b/src/rx.c
@@ -8,6 +8,8 @@
  *               All rights reserved.
 */
 
+#ifdef __Unikraft__
+
 #include "netif.h"
 #include "result.h"
 
@@ -95,3 +97,5 @@ CAMLprim value uk_netdev_rx(value v_netif, value v_buf, value v_size)
   v_result = alloc_result_ok(Val_int(size));
   CAMLreturn(v_result);
 }
+
+#endif /* __Unikraft__ */

--- a/src/rx.c
+++ b/src/rx.c
@@ -58,14 +58,12 @@ static int netdev_rx(struct netif* netif, uint8_t *buf, unsigned *size,
 
   const bool more = uk_netdev_status_more(rc);
 
-  if (bufsize < nb->len) {
-    *err = "Not enough room in buffer to write packet";
-    uk_netbuf_free_single(nb);
-    return -1;
-  }
-
-  memcpy(buf, nb->data, nb->len);
-  *size = nb->len;
+  /* If bufsize < nb->len, simply drop the extra trailing bytes, as they cannot
+   * be part of the packet payload or it would exceed MTU; so define len, the
+   * number of bytes to copy, to be the minimum of bufsize and nb->len */
+  const unsigned len = (bufsize < nb->len) ? bufsize : nb->len;
+  memcpy(buf, nb->data, len);
+  *size = len;
   uk_netbuf_free_single(nb);
 
   return (more ? 1 : 0);

--- a/src/tx.c
+++ b/src/tx.c
@@ -8,6 +8,8 @@
  *               All rights reserved.
 */
 
+#ifdef __Unikraft__
+
 #include "netif.h"
 #include "result.h"
 
@@ -104,3 +106,5 @@ CAMLprim value uk_netdev_tx(value v_netif, value v_netbuf, value v_size)
   v_result = alloc_result_ok(Val_unit);
   CAMLreturn(v_result);
 }
+
+#endif /* __Unikraft__ */


### PR DESCRIPTION
The main fix this brings is to handle packets that appear to be larger than the expected maximal size (MTU + header size), by simply ignoring the extra bytes. Tests on QEMU show that the packet size reported by the virtio layer are always 10 byte larger than the actual packet. So we simply drop those extra bytes when we know they cannot be part of the packet.

The other commits fix smaller details.

cc @n-osborne